### PR TITLE
Some performance enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,23 @@
 [root]
 name = "rmcr"
 version = "0.1.0"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[[package]]
+name = "libc"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Martin Habovštiak <martin.habovstiak@gmail.com>"]
 
 [dependencies]
+memchr = "0.1.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,41 +1,83 @@
-use std::io::{stdin, stdout, stderr, Read, Write};
-use std::io;
-use std::process::exit;
+extern crate memchr;
 
-fn has_data(size: usize) -> Option<usize> {
-    match size {
-        0 => None,
-        x => Some(x),
+use std::io::{self, Read, Write};
+use std::process::exit;
+use memchr::memchr;
+
+struct NewlineWrapper<R: Read> {
+    inner: R
+}
+
+impl<R: Read> NewlineWrapper<R> {
+    fn new(inner: R) -> Self {
+        NewlineWrapper {
+            inner: inner,
+        }
+    }
+}
+
+impl<R: Read> Read for NewlineWrapper<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let size = self.inner.read(buf)?;
+        let mut start = 0;
+        while start < size {
+            let to_check = &mut buf[start..size];
+            match memchr(b'\r', to_check) {
+                Some(i) => {
+                    to_check[i] = b'\n';
+                    start += i + 1;
+                },
+                None => break,
+            }
+        }
+        Ok(size)
     }
 }
 
 fn run() -> io::Result<()> {
-    let mut stdin = stdin();
-    let mut stdout = stdout();
-    let mut buf = [0; 4096];
+    let stdin = io::stdin();
+    let stdin = stdin.lock();
+    let mut stdin = NewlineWrapper::new(stdin);
+    let stdout = io::stdout();
+    let stdout = stdout.lock();
+    let mut stdout = io::LineWriter::new(stdout);
 
-    while let Some(size) = stdin.read(&mut buf).map(has_data)? {
-        let mut flush = false;
-
-        for b in &mut buf[0..size] {
-            if *b == b'\r' {
-                *b = b'\n';
-                flush = true;
-            }
-        }
-
-        stdout.write(&buf[0..size])?;
-        if flush {
-            stdout.flush()?;
-        }
-    }
-
-    Ok(())
+    io::copy(&mut stdin, &mut stdout).map(|_| ())
 }
 
 fn main() {
     if let Err(e) = run() {
-        let _ = write!(stderr(), "Error: {}", e);
+        let _ = write!(io::stderr(), "Error: {}", e);
         exit(1);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::io::Read;
+    use super::NewlineWrapper;
+
+    fn replacement_test(input: &[u8]) {
+        let mut expected_output = input.to_vec();
+        for ch in expected_output.iter_mut() {
+            if (*ch) == b'\r' {
+                *ch = b'\n';
+            }
+        }
+
+        let mut output = vec![0u8; input.len()];
+        let mut input = NewlineWrapper::new(input);
+        input.read_exact(&mut output).unwrap();
+        assert_eq!(&output[..], &expected_output[..]);
+    }
+
+    #[test]
+    fn last_char_lf() {
+        replacement_test(b"hi there\r");
+    }
+
+    #[test]
+    fn multiple_lf() {
+        replacement_test(b"\r\r\rword\rmiddle\r\rrest");
     }
 }


### PR DESCRIPTION
* Use memchr to find '\r'
* Lock stdin/stdout
* Refactor to use a wrapper type around Read instances, which replaces
    '\r' with '\n'
* Refactor to use std lib LineWriter to automatically flush on newline
    characters
* Use std::io::copy to fully copy from stdin to stdout
* Add some small tests to verify NewlineWrapper type